### PR TITLE
feat: add primary color theme for button

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,5 +2,6 @@
   height: 100vh;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-around;
+  padding: 0px 20%;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,9 @@ import StyledButton from './components/StyledButton/StyledButton'
 function App () {
   return (
     <div className='App'>
-      <StyledButton text='Button' />
+      <StyledButton text='Button' primary />
+      <StyledButton text='Button' secondary />
+      <StyledButton text='Button' tertiary />
     </div>
   )
 }

--- a/src/components/StyledButton/StyledButton.jsx
+++ b/src/components/StyledButton/StyledButton.jsx
@@ -1,7 +1,8 @@
 import { Button } from './styled'
-const StyledButton = ({ text }) => {
+const StyledButton = (props) => {
+  const { text } = props
   return (
-    <Button tertiary>{text}</Button>
+    <Button {...props}>{text}</Button>
   )
 }
 

--- a/src/components/StyledButton/styled/index.js
+++ b/src/components/StyledButton/styled/index.js
@@ -1,28 +1,31 @@
 import styled from 'styled-components'
 export const Button = styled.button`
-    background-color: #01579b;
     color: #fff;
     font-size : 16px;
     line-height : 24px;
     font-weight: 400;
     padding: 6px 12px;
     border-radius: 5px;
-    border: 1px solid #01579b;
+    border: 1px solid;
 
-    &:hover {
-        background-color: #0d47a1;
-        border-color: #0d47a1;
-    }
+    ${props => props.primary && `
+        background-color: #01579b;
+        border-color: #01579b;
+        &:hover {
+            background-color: #0d47a1;
+            border-color: #0d47a1;
+        }
 
-    &:active {
-        background-color: #1565c0;
-        border-color: #1565c0;
-    }
+        &:active {
+            background-color: #1565c0;
+            border-color: #1565c0;
+        }
 
-    &:disabled {
-        background-color: #0277bd;
-        border-color: #0277bd;
-    }
+        &:disabled {
+            background-color: #0277bd;
+            border-color: #0277bd;
+        }
+    `}
 
     ${props => props.secondary && `
         background-color : #33691e;


### PR DESCRIPTION
Closes #25 

## About this PR
This PR will do the following:
- Add a primary color theme for the button
- Enable button to accept props dynamically and take effects
- Place multiple buttons on the canvas to give the instant look of the progress