### PR TITLE
feat: add style for block button

### DIFF
--- a/src/components/StyledButton/styled/index.js
+++ b/src/components/StyledButton/styled/index.js
@@ -8,6 +8,10 @@ export const Button = styled.button`
     border-radius: ${props => props.pill ? 50 : 5}px;
     border: 1px solid;
 
+    ${props => props.fullWidth && `
+        width: 100%;
+    `}
+
     ${props => props.primary && `
         background-color: #01579b;
         border-color: #01579b;


### PR DESCRIPTION
Closes #32 

## About this PR
This PR will add styles for the fullWidth button. Users can get the full-width button variant by passing `fullWidth` prop.