### PR TITLE
feat: wrap the button's color-variants into color prop

### DIFF
--- a/src/components/StyledButton/StyledButton.jsx
+++ b/src/components/StyledButton/StyledButton.jsx
@@ -1,17 +1,15 @@
 import { Button } from './styled'
 import React from 'react'
 const StyledButton = (props) => {
-  const { text, primary, secondary, tertiary, children, ...restProps } = props
+  const { text, color, children, ...restProps } = props
   return (
     <Button
-      tertiary={tertiary}
-      secondary={secondary}
-      primary={primary}
+      color={color}
       hasChildren={children && true}
       {...restProps}
       hasText={text}
     >
-      {children && React.cloneElement(children, { primary, secondary, tertiary })}
+      {children && React.cloneElement(children, { color })}
       {text}
     </Button>
   )

--- a/src/components/StyledButton/styled/index.js
+++ b/src/components/StyledButton/styled/index.js
@@ -28,7 +28,7 @@ export const Button = styled.button`
         width: 100%;
     `}
 
-    ${props => props.primary && `
+    ${props => props.color === 'primary' && `
         background-color: #01579b;
         border-color: #01579b;
         &:hover {
@@ -47,7 +47,7 @@ export const Button = styled.button`
         }
     `}
 
-    ${props => props.secondary && `
+    ${props => props.color === 'secondary' && `
         background-color : #33691e;
         border-color : #33691e;
 
@@ -67,7 +67,7 @@ export const Button = styled.button`
         }
     `}
 
-    ${props => props.tertiary && `
+    ${props => props.color === 'tertiary' && `
         background-color : #ff6f00;
         border-color : #ff6f00;
 
@@ -116,7 +116,7 @@ export const Button = styled.button`
         }
     `}
 
-    ${props => props.outlined && props.primary && `
+    ${props => props.outlined && props.color === 'primary' && `
         color: #01579b;
         border-color: #01579b;
         background-color: transparent;
@@ -156,7 +156,7 @@ export const Button = styled.button`
         }
     `}
 
-    ${props => props.outlined && props.secondary && `
+    ${props => props.outlined && props.color === 'secondary' && `
         color: #33691e;
         border-color: #33691e;
         background-color: transparent;
@@ -196,7 +196,7 @@ export const Button = styled.button`
         }
     `}
 
-    ${props => props.outlined && props.tertiary && `
+    ${props => props.outlined && props.color === 'tertiary' && `
         color: #ff6f00;
         border-color: #ff6f00;
         background-color: transparent;


### PR DESCRIPTION
Closes #49 

## About this PR
This PR will wrap all the color-variants props (i.e. `primary`, `secondary` and `tertiary`) into single `color` prop.