### PR TITLE
feat: wrap the button's size-variants into size prop

### DIFF
--- a/src/components/StyledButton/StyledButton.jsx
+++ b/src/components/StyledButton/StyledButton.jsx
@@ -1,10 +1,11 @@
 import { Button } from './styled'
 import React from 'react'
 const StyledButton = (props) => {
-  const { text, color, children, ...restProps } = props
+  const { text, color, size, children, ...restProps } = props
   return (
     <Button
       color={color}
+      size={size}
       hasChildren={children && true}
       {...restProps}
       hasText={text}

--- a/src/components/StyledButton/styled/index.js
+++ b/src/components/StyledButton/styled/index.js
@@ -87,7 +87,7 @@ export const Button = styled.button`
         }
     `}
 
-    ${props => props.large && `
+    ${props => props.size === 'large' && `
         font-size : 20px;
         line-height : 30px;
         padding: ${!props.hasText
@@ -101,7 +101,7 @@ export const Button = styled.button`
         }
     `}
 
-    ${props => props.small && `
+    ${props => props.size === 'small' && `
         font-size : 14px;
         line-height : 21px;
         padding : 4px 8px;


### PR DESCRIPTION
Closes #48 

## About this PR
This PR will wrap all the size-variants props (i.e. `regular`, `small` and `large`) into single `size` prop.